### PR TITLE
[Feat] History Dropdown 구현

### DIFF
--- a/app/src/main/java/com/example/golmokstar/ui/screens/HistoryScreen.kt
+++ b/app/src/main/java/com/example/golmokstar/ui/screens/HistoryScreen.kt
@@ -36,7 +36,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -53,6 +55,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.golmokstar.R
 import com.example.golmokstar.ui.components.NavyBox
 import com.example.golmokstar.ui.components.YellowMarkerIcon
@@ -64,6 +68,7 @@ import com.example.golmokstar.ui.theme.TextBlack
 import com.example.golmokstar.ui.theme.TextDarkGray
 import com.example.golmokstar.ui.theme.TextLightGray
 import com.example.golmokstar.ui.theme.White
+import com.example.golmokstar.viewmodel.MapViewModel
 
 data class Sampledata(
     val name: String,
@@ -127,11 +132,14 @@ val samplehistorydata = listOf(
 
 @Preview
 @Composable
-fun HistoryScreen() {
-    var expanded by remember { mutableStateOf(false) }
-    var selectedItem by remember { mutableStateOf("전체") }
+fun HistoryScreen(viewModel: MapViewModel = hiltViewModel()) {
+    HistoryDropdownScreen(viewModel = viewModel)
 
     var showDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        viewModel.dropdownApi()
+    }
 
 
     LazyColumn(
@@ -141,14 +149,17 @@ fun HistoryScreen() {
             .padding(horizontal = 20.dp, vertical = 16.dp)
     ) {
         item {
-            // 드롭다운 메뉴
-            DropdownMenuSection(
-                expanded = expanded,
-                onExpandedChange = { expanded = it },
-                selectedItem = selectedItem,
-                onItemSelect = { selectedItem = it },
-                modifier = Modifier.width(180.dp).height(50.dp)
-            )
+
+            // 상단 왼쪽에 드롭다운 배치
+            Box(modifier = Modifier.fillMaxSize()) {
+                MapDropdownScreen(
+                    viewModel = viewModel(), // ViewModel 전달
+                    modifier = Modifier
+                        .align(Alignment.TopStart) // 드롭다운 위치를 Box 내에서 제어
+
+                )
+            }
+
             Spacer(modifier = Modifier.height(25.dp))
         }
 
@@ -191,19 +202,19 @@ fun HistoryScreen() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun DropdownMenuSection(
-    expanded: Boolean,
-    onExpandedChange: (Boolean) -> Unit,
-    selectedItem: String,
-    onItemSelect: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val items = listOf("전체", "옵션 1", "옵션 2", "옵션 3")
+fun HistoryDropdownScreen(viewModel: MapViewModel, modifier: Modifier = Modifier) {
+    val dropdownItems by viewModel.dropdownItems.observeAsState(initial = emptyList()) // API 데이터 옵저빙
+    var expanded by remember { mutableStateOf(false) }
+    var selectedItem by remember { mutableStateOf("선택해주세요") } // 기본값
 
     ExposedDropdownMenuBox(
         expanded = expanded,
-        onExpandedChange = onExpandedChange,
-        modifier = modifier
+        onExpandedChange = { expanded = it },
+        modifier = Modifier
+            .padding(16.dp)
+            .width(180.dp)
+            .height(50.dp)
+            .background(White)
     ) {
         OutlinedTextField(
             value = selectedItem,
@@ -211,47 +222,38 @@ fun DropdownMenuSection(
             readOnly = true,
             shape = RoundedCornerShape(12.dp),
             trailingIcon = {
-                IconButton(
-                    onClick = {
-                        onExpandedChange(!expanded)
-                    }
-                ) {
+                IconButton(onClick = { expanded = !expanded }) {
                     Icon(
-                        imageVector = if (expanded)
-                            ImageVector.vectorResource(id = R.drawable.arrow_drop_up_icon)
-                        else
-                            ImageVector.vectorResource(id = R.drawable.arrow_drop_down_icon),
-                        contentDescription = "드롭다운 열기",
-                        tint = IconGray
+                        imageVector = if (expanded) ImageVector.vectorResource(R.drawable.arrow_drop_up_icon)
+                        else ImageVector.vectorResource(R.drawable.arrow_drop_down_icon),
+                        contentDescription = "Toggle dropdown"
                     )
                 }
             },
             modifier = Modifier.menuAnchor(),
             colors = TextFieldDefaults.outlinedTextFieldColors(
-                containerColor = White,
-                focusedBorderColor = IconGray,
-                unfocusedBorderColor = IconGray,
-                focusedTextColor = TextDarkGray,
-                unfocusedTextColor = TextDarkGray
-            ),
-            textStyle = AppTypography.bodyMedium,
+                unfocusedBorderColor = IconGray,  // 포커스가 없는 상태일 때 외곽선 색상
+                focusedBorderColor = IconGray,    // 포커스가 있는 상태일 때 외곽선 색상
+                focusedLabelColor = TextDarkGray,
+                unfocusedLabelColor = TextDarkGray
+            )
+
+
         )
 
-        // ExposedDropdownMenu
         ExposedDropdownMenu(
             expanded = expanded,
-            onDismissRequest = {
-                // 외부 클릭 시 드롭다운을 닫기
-                onExpandedChange(false)
-            },
+            onDismissRequest = { expanded = false },
             modifier = Modifier.background(White)
+
         ) {
-            items.forEach { item ->
+            // API에서 받아온 데이터 표시
+            dropdownItems.forEach { item ->
                 DropdownMenuItem(
-                    text = { Text(text = item, style = AppTypography.bodyMedium, color = TextDarkGray) },
+                    text = { Text(item.title, style = AppTypography.bodyMedium, color = TextDarkGray) },
                     onClick = {
-                        onItemSelect(item)
-                        onExpandedChange(false)
+                        selectedItem = item.title
+                        expanded = false
                     }
                 )
             }

--- a/app/src/main/java/com/example/golmokstar/ui/screens/MapScreen.kt
+++ b/app/src/main/java/com/example/golmokstar/ui/screens/MapScreen.kt
@@ -110,7 +110,7 @@ import com.google.maps.android.compose.rememberCameraPositionState
 
 @Composable
 fun MapScreen(viewModel: MapViewModel = hiltViewModel()) {
-    TripDropdownScreen(viewModel = viewModel)
+    MapDropdownScreen(viewModel = viewModel)
 
     val context = LocalContext.current
     val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
@@ -488,7 +488,7 @@ fun MapScreen(viewModel: MapViewModel = hiltViewModel()) {
 
             // 상단 왼쪽에 드롭다운 배치
             Box(modifier = Modifier.fillMaxSize()) {
-                TripDropdownScreen(
+                MapDropdownScreen(
                     viewModel = viewModel(), // ViewModel 전달
                     modifier = Modifier
                         .align(Alignment.TopStart) // 드롭다운 위치를 Box 내에서 제어
@@ -501,7 +501,7 @@ fun MapScreen(viewModel: MapViewModel = hiltViewModel()) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TripDropdownScreen(viewModel: MapViewModel, modifier: Modifier = Modifier) {
+fun MapDropdownScreen(viewModel: MapViewModel, modifier: Modifier = Modifier) {
     val dropdownItems by viewModel.dropdownItems.observeAsState(initial = emptyList()) // API 데이터 옵저빙
     var expanded by remember { mutableStateOf(false) }
     var selectedItem by remember { mutableStateOf("선택해주세요") } // 기본값


### PR DESCRIPTION
dropdownApi 이용함
-> trips 이용해서 title, tripID 받아옴 로그로 확인 가능@
Map이랑 똑같은 구조!
launchedeffect(Unit)
이용해서 스크린 시작할때 호출하게끔함

**Check List :memo:**
- [x] Pull Request 제목 : [유형] 변경 사항 요약
- [x] 설명 & 이슈 번호 작성

**설명 (필수)**

이 PR에서 어떤 변경을 했는지 상세히 설명해주세요.
관련된 Issue 번호를 포함하세요.

1. #46 

2. 변경 사항
dropdownApi 이용해서 히스토리 드롭다운 리스트 받아옴
-> trips 이용해서 title, tripID 받아왔고 items.title로 리스트 띄움
받아온 title, tripId  로그로 확인 가능@
(Map이랑 똑같은 구조)
launchedeffect(Unit) -> 이용해서 스크린 시작할때 호출하게끔함


4. 스크린샷 (선택)
![Screenshot_20250228_004108](https://github.com/user-attachments/assets/866ad43a-26f2-485d-aeee-c0b674a2bc2b)

<br>

---

**review 참고 사항 (선택)**

추가로 알릴 내용이 있다면 여기에 작성해주세요.

1.

2.